### PR TITLE
Add `ignore` support to `noUndeclaredDependencies`

### DIFF
--- a/.changeset/thin-brooms-look.md
+++ b/.changeset/thin-brooms-look.md
@@ -1,0 +1,5 @@
+---
+"@biomejs/biome": patch
+---
+
+Fixed [#11012](https://github.com/biomejs/biome/issues/11012): [`noUndeclaredDependencies`](https://biomejs.dev/linter/rules/no-undeclared-dependencies/) now supports an `ignore` option for package imports that should not be checked.

--- a/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
+++ b/crates/biome_js_analyze/src/lint/correctness/no_undeclared_dependencies.rs
@@ -63,6 +63,7 @@ declare_lint_rule! {
     /// ## Options
     ///
     /// This rule supports the following options:
+    /// - `ignore`: A list of package names to ignore.
     /// - `devDependencies`: If set to `false`, then the rule will show an error when `devDependencies` are imported. Defaults to `true`.
     /// - `peerDependencies`: If set to `false`, then the rule will show an error when `peerDependencies` are imported. Defaults to `true`.
     /// - `optionalDependencies`: If set to `false`, then the rule will show an error when `optionalDependencies` are imported. Defaults to `true`.
@@ -73,6 +74,7 @@ declare_lint_rule! {
     /// ```json,options
     /// {
     ///   "options": {
+    ///     "ignore": ["vscode"],
     ///     "devDependencies": false,
     ///     "peerDependencies": false,
     ///     "optionalDependencies": false,
@@ -183,6 +185,13 @@ impl Rule for NoUndeclaredDependencies {
 
         let import_text = node.inner_string_text()?;
         let package_name = parse_package_name(import_text.text())?;
+        if ctx.options().ignore.as_ref().is_some_and(|ignored| {
+            ignored
+                .iter()
+                .any(|ignored_package| ignored_package.as_ref() == package_name)
+        }) {
+            return None;
+        }
         if is_available(package_name)
             // Self package imports
             // TODO: we should also check that an `.` exports exists.

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.options.json
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.options.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../../../../../packages/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "rules": {
+      "correctness": {
+        "noUndeclaredDependencies": {
+          "level": "error",
+          "options": {
+            "ignore": ["vscode"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts
@@ -30,6 +30,8 @@ import "#internal";
 // import from `@types/jest`
 import type * as jest from "lodash";
 
+import * as vscode from "vscode";
+
 import "bun";
 
 // NodeJS builtin

--- a/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts.snap
+++ b/crates/biome_js_analyze/tests/specs/correctness/noUndeclaredDependencies/valid.ts.snap
@@ -36,6 +36,8 @@ import "#internal";
 // import from `@types/jest`
 import type * as jest from "lodash";
 
+import * as vscode from "vscode";
+
 import "bun";
 
 // NodeJS builtin

--- a/crates/biome_rule_options/src/no_undeclared_dependencies.rs
+++ b/crates/biome_rule_options/src/no_undeclared_dependencies.rs
@@ -9,6 +9,10 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields, default)]
 pub struct NoUndeclaredDependenciesOptions {
+    /// A list of package names to ignore.
+    #[serde(skip_serializing_if = "Option::<_>::is_none")]
+    pub ignore: Option<Box<[Box<str>]>>,
+
     /// If set to `false`, then the rule will show an error when `devDependencies` are imported. Defaults to `true`.
     #[serde(skip_serializing_if = "Option::<_>::is_none")]
     pub dev_dependencies: Option<DependencyAvailability>,


### PR DESCRIPTION
Fixes #11012

`noUndeclaredDependencies` now accepts an `ignore` option so specific package imports can be excluded from the rule check. The rule implementation, rule options schema, and tests were updated to cover ignored imports such as `vscode`.

Test plan:
- Added a valid rule fixture with `ignore: ["vscode"]`
- Updated the corresponding snapshot
- Added the rule option to the shared options type

> This PR was implemented with guidance from Claude Code AI assistant.